### PR TITLE
Add directives that result in decimals that are not zero padded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 awstats-icon
 icon
 dist/*
+venv/*

--- a/build.py
+++ b/build.py
@@ -14,7 +14,7 @@ def main():
     soup = BeautifulSoup(body)
 
     table = soup.find(id='strftime-and-strptime-behavior').find('table')
-    example_date = datetime.datetime(2013, 12, 25, 17, 15, 30)
+    example_date = datetime.datetime(2013, 9, 3, 9, 6, 5)
 
     directives = []
     for row in table.select('tbody > tr'):
@@ -26,8 +26,27 @@ def main():
         directives.append({
             'directive': directive,
             'meaning': meaning,
-            'example': example,
+            'example': example
         })
+
+        # also add the non zero padded version for some of them
+        # http://stackoverflow.com/questions/28894172/why-does-d-or-e-remove-the-leading-space-or-zero
+
+        exclude = ['%f', '%y']
+        if 'zero-padded' in meaning and directive not in exclude:
+            non_zero_padding_decimal = directive.replace("%", "%-")
+            non_zero_padding_example = example_date.strftime(
+                non_zero_padding_decimal
+            )
+
+            non_zero_padding_meaning = (
+                meaning.replace("zero-padded", "") + " (Platform specific)")
+
+            directives.append({
+                'directive': non_zero_padding_decimal,
+                'meaning': non_zero_padding_meaning,
+                'example': non_zero_padding_example
+            })
 
     template = open('templates/index.html.mustache').read()
     context = {

--- a/resources/edify.css
+++ b/resources/edify.css
@@ -26,6 +26,7 @@ td, th {
     text-align: left;
     vertical-align: top;
 }
+
 tr:nth-child(even) {
     background-color: #eee;
 }

--- a/templates/index.html.mustache
+++ b/templates/index.html.mustache
@@ -45,8 +45,17 @@
 
     <p class="source"><strong>Source:</strong>
       <a href="http://www.python.org/">Python</a>&#8217;s
-      <code><a href="http://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior">strftime</a></code>
-      documentation.</p>
+      <code><a href="http://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior" target="_blank">strftime</a></code>
+      documentation.
+    </p>
+
+    <a name="platforms"></a>
+    <p class="platforms"><strong>Platform specific directives:</strong>
+      The full set of format codes supported varies across platforms, because Python calls the platform C library's strftime() function, and platform variations are common. To see the full set of format codes supported on your platform, consult the <a href="http://man7.org/linux/man-pages/man3/strftime.3.html" target="_blank"><code>strftime(3)</code> documentation</a>.
+      <br />
+      <br />
+      The Python docs contain all the format codes that the C standard (1989 version) requires, and these work on all platforms with a standard C implementation. Note that the 1999 version of the C standard added additional format codes. These include codes for non-zero-padded numbers, that can be obtained by appending a dash (-) after the percent (%) sign.
+    </p>
 
     <p class="explanation"><strong>Why?</strong> I need to use
       Python&#8217;s <code>strftime</code> rarely enough that I can&#8217;t
@@ -56,15 +65,15 @@
       to put this reference page up.</p>
 
     <p class="who"><strong>Who?</strong> This was slapped together on a whim
-      by <a href="https://twitter.com/mccutchen">Will McCutchen</a>, who is
+      by <a href="https://twitter.com/mccutchen" target="_blank">Will McCutchen</a>, who is
       just slouching on the shoulders of the awesome
-      <a href="http://docs.python.org/2/about.html">Python documentation team</a>.
-      The source code is <a href="https://github.com/mccutchen/strftime.org">on Github</a>
+      <a href="http://docs.python.org/2/about.html" target="_blank">Python documentation team</a>.
+      The source code is <a href="https://github.com/mccutchen/strftime.org" target="_blank">on Github</a>
       and pull requests are welcome!</p>
 
     <p class="when"><strong>When?</strong> Last updated {{timestamp}}.</p>
 
-    <a href="https://github.com/mccutchen/strftime.org"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
+    <a href="https://github.com/mccutchen/strftime.org" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
 
     <script type="text/javascript">
       var _gaq = _gaq || [];


### PR DESCRIPTION
Hello,

I added mentions for using strftime to generate decimals without being zero-padded. This is missing from the Python docs, but is explained in the docs of the C function Python is using behind the scenes. Please see here for more details: http://stackoverflow.com/questions/28894172/why-does-d-or-e-remove-the-leading-space-or-zero

As far as StackOverflow users say, this seems to be limited to UNIX systems